### PR TITLE
hc-870 fix zone setting

### DIFF
--- a/alz-linux-vm/main.tf
+++ b/alz-linux-vm/main.tf
@@ -29,6 +29,7 @@ locals {
         lun           = disk.lun
         type          = disk.type
         create_option = disk.create_option
+        zone          = vm.zone
         tags          = vm.tags
       }
     ]
@@ -116,6 +117,7 @@ resource "azurerm_linux_virtual_machine" "alz_linux" {
   location                        = data.azurerm_resource_group.alz_linux.location
   resource_group_name             = data.azurerm_resource_group.alz_linux.name
   size                            = each.value.vm_size
+  zone                            = each.value.zone
   admin_username                  = each.value.admin_user
   disable_password_authentication = false
   admin_password                  = random_password.alz_linux[each.key].result
@@ -180,6 +182,7 @@ resource "azurerm_managed_disk" "alz_linux" {
   storage_account_type = each.value.type
   create_option        = each.value.create_option
   disk_size_gb         = each.value.size
+  zone                 = each.value.zone
   tags                 = each.value.tags
 }
 

--- a/alz-linux-vm/variables.tf
+++ b/alz-linux-vm/variables.tf
@@ -10,7 +10,7 @@ variable "vm_specifications" {
     vm_size               = string
     marketplace_image     = optional(bool)
     marketplace_plan      = optional(map(string))
-    zone                  = string
+    zone                  = optional(string)
     publisher             = string
     offer                 = string
     sku                   = string

--- a/alz-win-vm/main.tf
+++ b/alz-win-vm/main.tf
@@ -29,6 +29,7 @@ locals {
         size          = disk.size
         type          = disk.type
         create_option = disk.create_option
+        zone          = vm.zone
         tags          = vm.tags
       }
     ]
@@ -121,6 +122,7 @@ resource "azurerm_windows_virtual_machine" "alz_win" {
   location                   = data.azurerm_resource_group.alz_win.location
   resource_group_name        = data.azurerm_resource_group.alz_win.name
   size                       = each.value.vm_size
+  zone                       = each.value.zone
   admin_username             = each.value.admin_user
   admin_password             = random_password.alz_win[each.key].result
   computer_name              = each.key # remember this can only be 15 characters max
@@ -184,6 +186,7 @@ resource "azurerm_managed_disk" "alz_win" {
   storage_account_type = each.value.type
   create_option        = each.value.create_option
   disk_size_gb         = each.value.size
+  zone                 = each.value.zone
   tags                 = each.value.tags
 }
 

--- a/alz-win-vm/variables.tf
+++ b/alz-win-vm/variables.tf
@@ -9,7 +9,7 @@ variable "vm_specifications" {
     vm_size               = string
     marketplace_image     = optional(bool)
     marketplace_plan      = optional(map(string))
-    zone                  = string
+    zone                  = optional(string)
     publisher             = string
     offer                 = string
     sku                   = string


### PR DESCRIPTION
Fixing the setting of Availability Zone by adding the zone variable into the resource blocks for virtual_machine and managed_disk.
Changed the zone variable to be optional for backward compatibility so that it doesn't affect VMs that are already built without Availability Zone set.