### PR TITLE
fix broken url for build_vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Due to the way that the Terraform azure provider makes a distinction between Lin
 
 See specific documentation in each module. Documentation is generated when a PR is opened using [terraform-docs](https://github.com/terraform-docs/terraform-docs/).
 
-Module usage examples and further useful documentation can be found in the [ALZ user guides](https://ministryofjustice.github.io/azure-landing-zone-user-guides/documentation/building-alz-vms.html)
+Module usage examples and further useful documentation can be found in the [ALZ user guides](https://ministryofjustice.github.io/azure-landing-zone-user-guides/documentation/diy/build_vm/index.html#building-vms-in-alz)


### PR DESCRIPTION
Fix the broken url for the `ALZ user guides` link which should point at the [building-vms-in-alz](https://ministryofjustice.github.io/azure-landing-zone-user-guides/documentation/diy/build_vm/index.html#building-vms-in-alz) page.