### PR TITLE
Hc-1049 Retirement of Microsoft management agent

### DIFF
--- a/alz-win-vm/main.tf
+++ b/alz-win-vm/main.tf
@@ -251,7 +251,6 @@ resource "azurerm_virtual_machine_extension" "alz_win_ama" {
     SETTINGS
 }
 /*
-
 # Also install "old" Log Analytics agent (extension called MicrosoftMonitoringAgent...) required to collect Change Tracking info
 # This ultimately allows collection of data on Files, Services and Registry key changes so alerts can be created based on this
 # This shouldn't have been required as this functionality is baked into the AMA installed above but it currently doesn't work...

--- a/alz-win-vm/main.tf
+++ b/alz-win-vm/main.tf
@@ -250,11 +250,12 @@ resource "azurerm_virtual_machine_extension" "alz_win_ama" {
     }
     SETTINGS
 }
+/*
 
 # Also install "old" Log Analytics agent (extension called MicrosoftMonitoringAgent...) required to collect Change Tracking info
 # This ultimately allows collection of data on Files, Services and Registry key changes so alerts can be created based on this
 # This shouldn't have been required as this functionality is baked into the AMA installed above but it currently doesn't work...
-# Confirmed with MS this should be fixed when it comes into General Availability 
+# Confirmed with MS this should be fixed when it comes into General Availability (24/07/2024 AMA can now collect change tracking info)
 resource "azurerm_virtual_machine_extension" "alz_win_mma" {
   for_each                   = { for k, v in var.vm_specifications : k => v if v.monitor }
   depends_on                 = [time_sleep.wait_30_seconds_av] # See README
@@ -281,6 +282,7 @@ resource "azurerm_virtual_machine_extension" "alz_win_mma" {
 
   tags = each.value.tags
 }
+*/
 
 # associate to a Data Collection Rule
 resource "azurerm_monitor_data_collection_rule_association" "alz_win" {


### PR DESCRIPTION
The Log Analytics agent will be [retired on August 31, 2024](https://azure.microsoft.com/updates/were-retiring-the-log-analytics-agent-in-azure-monitor-on-31-august-2024/). 

Removing the code related to the MMA agent from the VM module.