### PR TITLE
fix dependabot terraform directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -9,13 +9,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
+  
   - package-ecosystem: "terraform"
-    directory: "/tests/terraform/infra-build", "/tests/terraform/vm-build"
+    directory: "/tests/terraform/infra-build"
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 5 # default, let's see how we go
+    open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"] # let's have more control over major changes
+        update-types: ["version-update:semver-major"]
+  
+  - package-ecosystem: "terraform"
+    directory: "/tests/terraform/vm-build"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Change the `dependabot.yml` file to fix the parse error so that dependabot can check for dependencies.

The yaml in the original code was invalid as you cannot specify multiple directories separated by a comma in the same package-ecosystem block.

This PR separates out the test directories into their own blocks for:
```
directory: "/tests/terraform/infra-build"
directory: "/tests/terraform/vm-build"
```

Allowing dependabot to change the versions in the test folder shouldn't mean we need to publish a new version of the module, unless the tests fail because of the version change and fixes need to be made to the module.

The URL for dependabot guidance is also updated to a working version as found in our other repos.
