### PR TITLE
change dependabot to use directories and groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  
+
   - package-ecosystem: "terraform"
-    directory: "/tests/terraform/infra-build"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-  
-  - package-ecosystem: "terraform"
-    directory: "/tests/terraform/vm-build"
+    directories:
+      - "/tests/terraform/*"
+    groups:
+      vm-module-tests:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
Change the `dependabot.yml` file so that it uses these options:
1. [directories](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories) which became available on 25/06/2024 as per this [blog](https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/) which allows wildcard for the first time.
2. [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) so that multiple dependencies are grouped together in a single PR.