### PR TITLE
remove equals from azurerm version

### DIFF
--- a/tests/terraform/infra-build/versions.tf
+++ b/tests/terraform/infra-build/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.33.0"
+      version = "3.33.0"
     }
   }
 }


### PR DESCRIPTION
Removing the equals sign from `terraform/infra-build/versions.tf` for `hashicorp/azurem` to see if it helps with dependabot and having it only produce 1 PR for multiple directories.