### PR TITLE
HC-1177 add os_disk_size variable

### DIFF
--- a/alz-linux-vm/main.tf
+++ b/alz-linux-vm/main.tf
@@ -121,6 +121,7 @@ resource "azurerm_linux_virtual_machine" "alz_linux" {
     name                 = "osDisk-${each.key}"
     caching              = "ReadWrite"
     storage_account_type = each.value.os_disk_type
+    disk_size_gb         = each.value.os_disk_size
   }
 
   boot_diagnostics {

--- a/alz-linux-vm/variables.tf
+++ b/alz-linux-vm/variables.tf
@@ -16,6 +16,7 @@ variable "vm_specifications" {
     offer                                                  = string
     sku                                                    = string
     version                                                = string
+    os_disk_size                                           = optional(number)
     os_disk_type                                           = optional(string, "Standard_LRS")
     admin_user                                             = optional(string, "azureuser")
     bypass_platform_safety_checks_on_user_schedule_enabled = optional(string, "false")

--- a/alz-win-vm/main.tf
+++ b/alz-win-vm/main.tf
@@ -124,6 +124,7 @@ resource "azurerm_windows_virtual_machine" "alz_win" {
     name                 = "osDisk-${each.key}"
     caching              = "ReadWrite"
     storage_account_type = each.value.os_disk_type
+    disk_size_gb         = each.value.os_disk_size
   }
 
   boot_diagnostics {

--- a/alz-win-vm/variables.tf
+++ b/alz-win-vm/variables.tf
@@ -15,6 +15,7 @@ variable "vm_specifications" {
     offer                                                  = string
     sku                                                    = string
     version                                                = string
+    os_disk_size                                           = optional(number)
     os_disk_type                                           = optional(string, "Standard_LRS")
     admin_user                                             = optional(string, "azureuser")
     bypass_platform_safety_checks_on_user_schedule_enabled = optional(string, "false")
@@ -102,4 +103,3 @@ variable "recovery_vault_resource_group" {
   type        = string
   default     = null
 }
-


### PR DESCRIPTION
Adding new optional variable `os_disk_size` to `vm_specifications` as we have a use case that requires a disk size larger than the default for the image.

See [HC-1177](https://dsdmoj.atlassian.net/browse/HC-1177) for testing the Kali Linux VM in dev that will be used for the ITHC being carried out by BSI.

The default for the kali image is 40GB but BSI have requested a minimum of 100GB so having the option of increasing the size when required will be useful.

**Note**: there is a warning on the Terraform documentation [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#disk_size_gb-3) that mentions needing to repartition the disk.
However, this was not required during testing but worth being aware of.